### PR TITLE
Remove redis port expose

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -20,8 +20,6 @@ services:
       - makeuoft-2021
   redis:
     image: redis:6-alpine
-    ports:
-      - 6379:6379
     deploy:
       replicas: 1
       update_config:


### PR DESCRIPTION
## Overview

Deployment is currently failing because of conflicts with the Newhacks redis service, also exposed on port 6379. We don't need to expose the service at all, since the services will talk over the swarm bridge network.

- Removes ports section for the redis service is the deployment docker compose file