### PR TITLE
Add Reimbursement Message to Acceptance Emails

### DIFF
--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -185,7 +185,7 @@
                             </div>
                             <div class="collapsible-body">
                                 <span>
-                                    Unfortunately, our team will not be able to ship out any hardware for MakeUofT 2021. But the first 200 people to be accepted will be able to get a $25 reimbursement after submitting a demo with their team!
+                                    Unfortunately, our team will not be able to ship out any hardware for MakeUofT 2021. However, the first 200 people to apply and be accepted will be able to get a $25 reimbursement after submitting a demo of their project! If you submit as a team, each eligible team member will receive a separate reimbursement.
                                 </span>
                             </div>
                         </li>
@@ -240,7 +240,7 @@
                             </div>
                             <div class="collapsible-body">
                                 <span>
-                                    The first 200 people to be accepted (and submit a demo) will be able to get a $25 reimbursement!
+                                    The first 200 people to apply will be able to get a $25 reimbursement after submitting a demo of their project, as an e-transfer to the email used during their application. We'll let you know in your acceptance email if you were one of the first 200 people to apply.
                                 </span>
                             </div>
                         </li>

--- a/hackathon_site/hackathon_site/tests.py
+++ b/hackathon_site/hackathon_site/tests.py
@@ -133,7 +133,7 @@ class SetupUserMixin:
         return team
 
     def _review(
-        self, application=None, reviewer=None, **kwargs,
+        self, application=None, reviewer=None, save=True, **kwargs,
     ):
         if application is None:
             application = self.user.application
@@ -163,7 +163,12 @@ class SetupUserMixin:
         }
         default_kwargs.update(kwargs)
 
-        self.review = Review.objects.create(**default_kwargs)
+        review = Review(**default_kwargs)
+        if save:
+            review.save()
+            self.review = review
+
+        return review
 
 
 @override_settings(IN_TESTING=False)

--- a/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
@@ -2,10 +2,13 @@
 
 <p>Hello {{ user.first_name|striptags }},</p>
 
-<p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}!
-To confirm your attendance, visit your <a href="{{ dashboard_url }}">dashboard</a> to RSVP by {{ rsvp_deadline }} otherwise your spot will be given to other applicants. Alternatively, you can press the "Cannot attend" button.</p>
+<p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}!</p>
 
-<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
+{% if reimbursement_eligible %}
+<p>Because you were one of the first 200 people to apply, as long as you submit your project you will be eligible for a $25 reimbursement at the end of the event. Once your project has been submitted, you will receive an e-transfer from us to this email address, {{ user.email }}. If you submit with teammates, and any of them also received this message, you will each be separately eligible for the reimbursement.</p>
+
+{% endif %}
+<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us.</p>
 
 <p>Happy hacking,<br>
 The {{ hackathon_name }} Team

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -318,29 +318,11 @@ class MailerTestCase(SetupUserMixin, TestCase):
         users = User.objects.filter(username__in=[u.username for u in users])
         teams = Team.objects.filter(team_code__in=[t.team_code for t in teams])
 
-        application_data = {
-            "birthday": date(2000, 1, 1),
-            "gender": "no-answer",
-            "ethnicity": "no-answer",
-            "phone_number": "1234567890",
-            "school": "UofT",
-            "study_level": "other",
-            "graduation_year": 2020,
-            "q1": "hi",
-            "q2": "there",
-            "q3": "foo",
-            "conduct_agree": True,
-            "data_agree": True,
-            "resume": "uploads/resumes/my_resume.pdf",
-        }
-
         applications = []
         # Not using bulk_create here so we can be sure we're using the
         # right applications below
         for user, team in zip(users, teams):
-            application = Application.objects.create(
-                user=user, team=team, **application_data
-            )
+            application = self._apply_as_user(user=user, team=team)
             applications.append(application)
 
         reviews = []

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -220,12 +220,7 @@ class MailerTestCase(SetupUserMixin, TestCase):
 
         link = f"http://testserver{reverse('event:dashboard')}"
 
-        rsvp_deadline = (
-            datetime.now().date() + timedelta(days=settings.RSVP_DAYS)
-        ).strftime("%b %d %Y")
-
         self.assertIn(link, mail.outbox[0].body)
-        self.assertIn(rsvp_deadline, mail.outbox[0].body)
         self.assertIn(settings.HACKATHON_NAME, mail.outbox[0].body)
         self.assertIn(settings.PARTICIPANT_PACKAGE_LINK, mail.outbox[0].body)
         self.assertIn(settings.CHAT_ROOM[0], mail.outbox[0].body)

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -4,10 +4,10 @@ from django.urls import reverse_lazy
 from django.shortcuts import redirect
 from django.views.generic.edit import FormView
 from django.contrib.auth.mixins import UserPassesTestMixin
-
 from django.template.loader import render_to_string
 from django.core import mail
 
+from registration.models import Application
 from review.forms import MailerForm
 from review.models import Review
 from hackathon_site import settings
@@ -46,7 +46,7 @@ class MailerView(UserPassesTestMixin, FormView):
             updated_at__gte=date_start,
             updated_at__lte=date_end,
             decision_sent_date__isnull=True,
-        )[:quantity]
+        ).order_by("id")[:quantity]
 
         # Get a mail socket connection and manually open it
         connection = mail.get_connection(fail_silently=False)
@@ -56,14 +56,24 @@ class MailerView(UserPassesTestMixin, FormView):
             for review in queryset:
                 current_date = datetime.now().date()
 
+                # The first 200 people to apply are eligible for reimbursement,
+                # as long as they were accepted and submit a project
+                application_position = (
+                    Application.objects.filter(
+                        created_at__lt=review.application.created_at
+                    ).count()
+                    + 1
+                )
+                reimbursement_eligible = (
+                    review.status == "Accepted" and application_position <= 200
+                )
+
                 # Create context data for rendering the template. Note that this assumes that both the message
                 # and html_message have identical context data
                 render_to_string_context = {
                     "user": review.application.user,
                     "request": self.request,
-                    "rsvp_deadline": (
-                        current_date + timedelta(days=settings.RSVP_DAYS)
-                    ).strftime("%b %d %Y"),
+                    "reimbursement_eligible": reimbursement_eligible,
                 }
 
                 review.application.user.email_user(


### PR DESCRIPTION
## Overview

- Resolves #18
- Resolves #12
- The first 200 people to submit applications will be told they can get reimbursed for $25 if they also submit a project in their acceptance email. The count continues and skips over rejected applicants, so only the first 200 to apply can possibly get the reimbursement if accepted.
- Also removes the notice to RSVP from the acceptance email

## Unit Tests Created

- Removed the test that checked for the RSVP message in the acceptance email
- Added a test that creates 204 applications, some of which are rejected. Tests that only the accepted people below application 201 get the reimbursement message.

## Steps to QA

- Read the updated email text and see if it makes sense
- Verify that RSVP messages are gone from the emails and mailer view
- You could create 200 users and test, but I value your sanity. Make sure that the tests capture what you would have done manually and you believe in them.
- Send out one email just to make sure it gets rendered properly still.

