### PR TITLE
Added CSV download functionality for Applications page in the Admin site

### DIFF
--- a/hackathon_site/registration/admin.py
+++ b/hackathon_site/registration/admin.py
@@ -3,6 +3,7 @@ import functools
 
 from django.contrib import admin
 from django.http import HttpResponse
+from django.core.exceptions import ObjectDoesNotExist
 
 from registration.models import Application, Team as TeamApplied
 
@@ -31,12 +32,7 @@ class ExportCsvMixin:
 
     def export_as_csv(self, request, queryset):
         # Setup export_field_names and export_field attributes arrays
-        export_field_names = []
-        export_field_attributes = []
-        if self.export_fields:
-            for item in self.export_fields:
-                export_field_names.append(item[0])
-                export_field_attributes.append(item[1])
+        export_field_names, export_field_attributes = list(zip(*self.export_fields))
 
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = "attachment; filename={}.csv".format(
@@ -50,10 +46,10 @@ class ExportCsvMixin:
             for field in export_field_attributes:
                 try:
                     attributes.append(rgetattr(obj, field))
-                except Application.review.RelatedObjectDoesNotExist:
-                    attributes.append("None")
+                except ObjectDoesNotExist:
+                    attributes.append(None)
 
-            row = writer.writerow(attributes)
+            writer.writerow(attributes)
 
         return response
 

--- a/hackathon_site/registration/admin.py
+++ b/hackathon_site/registration/admin.py
@@ -31,7 +31,7 @@ class ExportCsvMixin:
     export_fields = []
 
     def export_as_csv(self, request, queryset):
-        # Setup export_field_names and export_field attributes arrays
+        # Setup export_field_names and export_field_attributes arrays
         export_field_names, export_field_attributes = list(zip(*self.export_fields))
 
         response = HttpResponse(content_type="text/csv")

--- a/hackathon_site/registration/admin.py
+++ b/hackathon_site/registration/admin.py
@@ -1,11 +1,52 @@
+import csv
+import functools
+
 from django.contrib import admin
+from django.http import HttpResponse
+
 from registration.models import Application, Team as TeamApplied
+
+
+def rgetattr(obj, attr, *args):
+    """
+    Recursive getattr, allows for nested attributes.
+    For example if you're in the Application class, you can't do getattr for user.first_name
+    But with rgetattr you can.
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
 
 
 class ApplicationInline(admin.TabularInline):
     model = Application
     autocomplete_fields = ("user",)
     extra = 0
+
+
+class ExportCsvMixin:
+    export_field_names = []
+    export_field_attributes = []
+
+    def export_as_csv(self, request, queryset):
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename={}.csv".format(
+            self.model._meta
+        )
+        writer = csv.writer(response)
+
+        writer.writerow(self.export_field_names)
+        for obj in queryset:
+            attributes = [
+                rgetattr(obj, field) for field in self.export_field_attributes
+            ]
+            row = writer.writerow(attributes)
+
+        return response
+
+    export_as_csv.short_description = "Export Selected"
 
 
 @admin.register(TeamApplied)
@@ -24,7 +65,7 @@ class TeamAppliedAdmin(admin.ModelAdmin):
 
 
 @admin.register(Application)
-class ApplicationAdmin(admin.ModelAdmin):
+class ApplicationAdmin(admin.ModelAdmin, ExportCsvMixin):
     autocomplete_fields = ("user", "team")
     list_display = ("get_full_name", "team", "school")
     search_fields = (
@@ -34,6 +75,42 @@ class ApplicationAdmin(admin.ModelAdmin):
         "team__team_code",
     )
     list_filter = ("school",)
+    actions = ["export_as_csv"]
+
+    export_field_names = [
+        "First Name",
+        "Last Name",
+        "Email",
+        "Team Code",
+        "Birthday",
+        "Gender",
+        "Ethnicity",
+        "School",
+        "Study Level",
+        "Graduation Year",
+        "Resume Sharing",
+        "Review Status",
+        "RSVP",
+        "Created At",
+        "Updated At",
+    ]
+    export_field_attributes = [
+        "user.first_name",
+        "user.last_name",
+        "user",
+        "team",
+        "birthday",
+        "gender",
+        "ethnicity",
+        "school",
+        "study_level",
+        "graduation_year",
+        "resume_sharing",
+        "review.status",
+        "rsvp",
+        "created_at",
+        "updated_at",
+    ]
 
     def get_full_name(self, obj):
         return f"{obj.user.first_name} {obj.user.last_name}"


### PR DESCRIPTION
## Overview

- Resolves #25
- Created an `ExportCsvMixin` to download CSV files for Admin site modules
- Added a function, `rgetattr` that recursively does `getattr`
- Adds export csv action to the `ApplicationAdmin` class
- Added `export_field_names` for the names at the top row of the csv
- Added `export_field_attributes` for the attributes for each column

## Unit Tests Created

- None


## Steps to QA

- Login to the admin site. Go to Registration_Applications.
- Check off which rows you want to download
- Click on the dropdown and select "Export Selected"
- Click on "Go" to  download the csv
- Check the CSV for the required fields and the correct values for those fields for the rows selected

