### PR TITLE
Added delay for email sending due to Amazon SES restrictions

### DIFF
--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -99,6 +99,7 @@ class MailerView(UserPassesTestMixin, FormView):
                 review.decision_sent_date = current_date
                 review.save()
 
+                # This is due to emails being sent with Amazon SES. They have a limit of 5 emails / sec with our tier.
                 time.sleep(0.2)
         except Exception as e:
             logger.error(e)

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta
 
 from django.urls import reverse_lazy
@@ -97,6 +98,8 @@ class MailerView(UserPassesTestMixin, FormView):
                 review.application.save()
                 review.decision_sent_date = current_date
                 review.save()
+
+                time.sleep(0.2)
         except Exception as e:
             logger.error(e)
             raise e


### PR DESCRIPTION
## Overview

- Resolves #37
- Added time delay each loop


## Unit Tests Created

- None


## Steps to QA

- Send some emails and see if 5 take about a second

