### PR TITLE
Fixed User email attribute to be user.email

### DIFF
--- a/hackathon_site/registration/admin.py
+++ b/hackathon_site/registration/admin.py
@@ -87,7 +87,7 @@ class ApplicationAdmin(admin.ModelAdmin, ExportCsvMixin):
     export_fields = [
         ("First Name", "user.first_name"),
         ("Last Name", "user.last_name"),
-        ("Email", "user"),
+        ("Email", "user.email"),
         ("Team Code", "team"),
         ("Birthday", "birthday"),
         ("Gender", "gender"),


### PR DESCRIPTION
## Overview

- Resolves #39
- Fixed User's Email in the CSV output to be `user.email` instead of just `user`
- Checked using the same steps in QA section that the change was correct.

## Unit Tests Created

- Still none


## Steps to QA

- Go to `Admin Site` -> `Applications`, select which apps you want to download and then download them using the dropdown. Inspect and make sure the email is correct.

