### PR TITLE
Use created_at for application ordering

### DIFF
--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -202,7 +202,7 @@ class TeamReviewAdmin(admin.ModelAdmin):
                 "applications", "applications__review", "applications__user"
             )
             .annotate(members_count=Count("applications", distinct=True))
-            .annotate(most_recent_submission=Max("applications__updated_at"))
+            .annotate(most_recent_submission=Max("applications__created_at"))
         )
 
     def get_members_count(self, obj):

--- a/hackathon_site/review/test_admin.py
+++ b/hackathon_site/review/test_admin.py
@@ -98,14 +98,14 @@ class TeamReviewListAdminTestCase(SetupUserMixin, TestCase):
         The submission date for a team is the date of the most recently submitted
         application on that team.
         """
-        # Mock the function django uses to set application.updated_at
+        # Mock the function django uses to set application.created_at
         old_updated_date = datetime(2020, 1, 1, 10, 0, 0, tzinfo=settings.TZ_INFO)
         with patch(
             "django.utils.timezone.now", MagicMock(return_value=old_updated_date)
         ):
             team = self._make_full_registration_team()
 
-        # Make a new team member, this time with application updated_at time set to something newer
+        # Make a new team member, this time with application created_at time set to something newer
         self.user4.delete()
         self.user4 = User.objects.create_user(
             username="lawren@harris", password="wxyz7890"


### PR DESCRIPTION
## Overview

- Resolves #38 
- Updates the queryset on the team review page to order by `created_at` instead of `updated_at`


## Unit Tests Created

- No changes


## Steps to QA

- grep / look through the project to make sure there isn't any more `application.updated_at`s that need changing
- Create a few teams and applications (via the admin site or by changing the registration open date and applying normally)
- Make sure the "Review next team" button gives the oldest unreviewed team, and the ordering of teams on the admin site doesn't change anymore

